### PR TITLE
Define default path for all execs.

### DIFF
--- a/manifests/file.pp
+++ b/manifests/file.pp
@@ -84,6 +84,9 @@ define deploy::file (
   $version         = undef,
   $package         = undef,
 ) {
+  Exec {
+    path => '/usr/local/bin:/usr/local/sbin:/usr/bin:/bin:/usr/sbin:/sbin',
+  }
 
   $file = $title
 


### PR DESCRIPTION
deploy::file out of the box throws path errors unless the user defines a default path for the Exec type elsewhere. A sane default should be provided here.
