### PR TITLE
Adding default value to untar command_options

### DIFF
--- a/manifests/untar.pp
+++ b/manifests/untar.pp
@@ -45,7 +45,7 @@
 define deploy::untar (
   $target,
   $command,
-  $command_options,
+  $command_options = undef,
   $strip,
   $strip_level,
   $owner,


### PR DESCRIPTION
in puppet 2.7 you cannot pass undef as a value, setting default value to undef
to avoid puppet error:

Must pass command_options to
Deploy::Untar[/tmp/deploy/atlassian-stash-2.10.1.tar.gz] at
/tmp/vagrant-puppet-2/modules-1/deploy/manifests/untar.pp:45 on node stash1
