### PR TITLE
Added 'onlyif' and 'unless' parameters

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -27,7 +27,7 @@ The following archives are supported:
       url     => 'http://mywebsite.co.za/development-tools/java',
       strip   => true,
     }
-  
+
     # Deploy another tar file
     deploy::file { 'jdk-8-ea-bin-b90-linux-x64-16_may_2013.tar.gz':
       target  => '/opt/development-tools/java/jdk1.8.0_b90',
@@ -52,12 +52,12 @@ The following archives are supported:
 #### Common Parameters
 
 *target*
-  
+
   * The target directory to decompress the archive file too.
   * This parameter is required
 
 *url*
-  
+
   * The URL where the file can be downloaded from.
   * This parameter is required. Do no specify the file name in the URL.
 
@@ -71,8 +71,8 @@ The following archives are supported:
   * Defaults to undefined
 
 *strip*
- 
-  * Strip root directory from archive file   
+
+  * Strip root directory from archive file
   * Defaults to 'false'
 
 *strip_level*
@@ -81,20 +81,30 @@ The following archives are supported:
   * Defaults to '1'
 
 *version*
-   
+
    * Define an arbitrary version number for the tar file. Must be an integer.
-   * **WARNING**: Incrementing this version number removes target directory and 
+   * **WARNING**: Incrementing this version number removes target directory and
    and redeploys tar file. Both version and package must be defined.
    * Defaults to undefined
 
 *package*
-   
-   * define an arbitrary package name for the tar file. 
+
+   * define an arbitrary package name for the tar file.
    * creates a static fact [package]\_version in /etc/facter/facts.d/ with
    file name [package].yaml. Both version and package must be defined.
    * Defaults to undefined
    * requires facter 1.7.x
    * requires the /etc/facter/facts.d/ directory structure to be in place.
+
+*onlyif*
+
+   * If this parameter is set, then this resource will only run if the command
+   returns 0.
+
+*unless*
+
+   * If this parameter is set, then this resource will run unless the command
+   returns 0.
 
 **If you decide to use the version and package parameters you get to keep both
 pieces if it breaks. I certainly don't recommend managing packages this way.**
@@ -116,4 +126,4 @@ pieces if it breaks. I certainly don't recommend managing packages this way.**
 ## Contributors
 * Jonathan Johnson
 * Andreyev Dias de Melo
-
+* Hamid Nazari

--- a/manifests/file.pp
+++ b/manifests/file.pp
@@ -20,6 +20,14 @@
 #   Overwrite the default command options. You probably don't want to do this.
 #   Defaults to undef
 #
+# [*onlyif*]
+#   If this parameter is set, then this resource will only run if the command
+#   returns 0.
+#
+# [*unless*]
+#   If this parameter is set, then this resource will run unless the command
+#   returns 0.
+#
 # [*fetch*]
 #   The path to the wget command.
 #   Defaults to '/usr/bin/wget'
@@ -88,6 +96,8 @@ define deploy::file (
   $url,
   $command         = undef,
   $command_options = undef,
+  $onlyif          = undef,
+  $unless          = undef,
   $fetch           = '/usr/bin/wget',
   $fetch_options   = '-q -c --no-check-certificate -O',
   $strip           = false,
@@ -130,7 +140,8 @@ define deploy::file (
   exec { "download_${file}":
     command         => "${fetch} ${fetch_options} ${deploy::tempdir}/${file} ${url}/${file}",
     creates         => "${deploy::tempdir}/${file}",
-    unless          => "test -d ${target}",
+    onlyif          => $onlyif,
+    unless          => $unless,
     timeout         => $download_timout,
     environment     => $env,
     require         => [ Class['deploy'], File[$deploy::tempdir], ],
@@ -145,6 +156,8 @@ define deploy::file (
       target          => $target,
       command         => $_command,
       command_options => $command_options,
+      onlyif          => $onlyif,
+      unless          => $unless,
       strip           => $strip,
       strip_level     => $strip_level,
       owner           => $owner,
@@ -161,6 +174,8 @@ define deploy::file (
       target          => $target,
       command         => $_command,
       command_options => $command_options,
+      onlyif          => $onlyif,
+      unless          => $unless,
       owner           => $owner,
       group           => $group,
       require         => Exec["download_${file}"],

--- a/manifests/untar.pp
+++ b/manifests/untar.pp
@@ -15,7 +15,15 @@
 # [*command_options*]
 #   Overwrite the default command options. You probably don't want to do this.
 #   This parameter is required
-
+#
+# [*onlyif*]
+#   If this parameter is set, then this resource will only run if the command
+#   returns 0.
+#
+# [*unless*]
+#   If this parameter is set, then this resource will run unless the command
+#   returns 0.
+#
 # [*strip*]
 #   Strip root directory from archive file
 #   This parameter is required
@@ -46,6 +54,8 @@ define deploy::untar (
   $target,
   $command,
   $command_options = undef,
+  $onlyif = undef,
+  $unless = undef,
   $strip,
   $strip_level,
   $owner,
@@ -75,15 +85,19 @@ define deploy::untar (
       fail('Dont know type')
     }
   }
+
   file { $target:
     ensure => directory,
     owner  => $owner,
     group  => $group,
   }
+
   # Uncompress downloaded file
   $_cmd = "${command} ${dl_cmd_options} ${file} -C ${target} ${strip_options} --no-same-owner"
   exec { "untarball_${file}":
     command     => $_cmd,
+    onlyif      => $onlyif,
+    unless      => $unless,
     subscribe   => File[$target],
     refreshonly => true,
     user        => $owner,


### PR DESCRIPTION
I'm only proposing this fix I quickly put together as a solution to a problem I was facing. This is going to produce different behaviour as I have changed a default value. So, perhaps you would want to tweak it or rewrite it in a more backward-compatible way.

**The Problem**
The first `puppet apply` worked just fine, but the second run would fail as it tried to uncompress a file that didn't exist anymore. The archive file gets removed at the end of the first run, `file.pp:174 exec { "cleanup_${file}":`.

Then the second run would not download the package because of `file.pp:133 unless => "test -d ${target}",`. Clearly the `$target` now exists from the previous run. After this, the uncompression commands start failing.

**Easier Solution**
Make sure `untar` and `unzip` resources also check for existence of `$target` in their corresponding files.

**Better Solution**
Allow user to decide when the code should ignore the commands and when it should not. In my case, I needed the package redownloaded and reextracted.

**Another Possible Nicety**
Perhaps we can introduce a `cache` or `allow_redownload` parameter that check for or ignore existence of the archive file on the system. 
