### PR TITLE
Added file:// and puppet:// URL style handling

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -60,6 +60,7 @@ The following archives are supported:
   
   * The URL where the file can be downloaded from.
   * This parameter is required. Do no specify the file name in the URL.
+  * For testing purpose, the module can handle URLs in from `file:///...` and `puppet:///...` style. You must not specify the file name with this URLs either. 
 
 *owner*
 


### PR DESCRIPTION
Hello Merritt.

As promised last week, I added support for local files and puppet style URL syntax. Sorry, I didn't wrote unit tests for this, because I'm still at the beginning of my puppet experience. But I tested both URL types in my test project.

Regards
 Andreas
